### PR TITLE
Various frontend compatibility tweaks

### DIFF
--- a/OIDC.Core-API/Controllers/Applications/ApplicationsController.cs
+++ b/OIDC.Core-API/Controllers/Applications/ApplicationsController.cs
@@ -36,7 +36,14 @@ namespace OAuthServer.Controllers.Applications
                 .FindByUserAsync(user);
 
             IList<ApplicationViewModel> applications = authorisedApplications
-                .Select(ua => ua.Application.ToViewModel())
+                .Select(ua =>
+                {
+                    List<Scope> scopes = ua.Scopes.Select(ua => ua.Scope).ToList();
+                    ApplicationViewModel vm = ua.Application.ToViewModel();
+                    vm.Scopes = scopes;
+
+                    return vm;
+                })
                 .ToList();
 
             return Ok(new
@@ -44,6 +51,24 @@ namespace OAuthServer.Controllers.Applications
                 status = 200,
                 message = "Authorised applications retrieved successfully",
                 data = applications
+            });
+        }
+
+        [HttpGet("published")]
+        public async Task<IActionResult> GetPublishedApplications()
+        {
+            User user = (User) HttpContext.Items["User"];
+
+            IList<Application> applications = await _applicationService.FindByAuthorAsync(user);
+            IList<ApplicationViewModel> applicationVms = applications
+                .Select(a => a.ToViewModel())
+                .ToList();
+
+            return Ok(new
+            {
+                status = 200,
+                message = "Published applications retrieved successfully",
+                data = applicationVms
             });
         }
 

--- a/OIDC.Core-API/Controllers/Users/UsersController.cs
+++ b/OIDC.Core-API/Controllers/Users/UsersController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OAuthServer.DAL.Entities;
 using OAuthServer.DAL.ViewModels.Controllers.Users;

--- a/OIDC.Core-API/DAL/Entities/Application.cs
+++ b/OIDC.Core-API/DAL/Entities/Application.cs
@@ -42,7 +42,8 @@ namespace OAuthServer.DAL.Entities
                 Description = Description,
                 FirstParty = FirstParty,
                 HomepageUrl = HomepageUrl,
-                RedirectUrl = RedirectUrl
+                RedirectUrl = RedirectUrl,
+                ClientId = ClientId
             };
         }
     }

--- a/OIDC.Core-API/DAL/Entities/Scope.cs
+++ b/OIDC.Core-API/DAL/Entities/Scope.cs
@@ -13,5 +13,7 @@ namespace OAuthServer.DAL.Entities
         public string Description { get; set; }
 
         public bool Dangerous { get; set; }
+
+        public string Icon { get; set; }
     }
 }

--- a/OIDC.Core-API/DAL/ViewModels/Entities/ApplicationViewModel.cs
+++ b/OIDC.Core-API/DAL/ViewModels/Entities/ApplicationViewModel.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using OAuthServer.DAL.Entities;
 
 namespace OAuthServer.DAL.ViewModels.Entities
 {
@@ -15,5 +18,11 @@ namespace OAuthServer.DAL.ViewModels.Entities
         public string RedirectUrl { get; set; }
 
         public bool FirstParty { get; set; }
+
+        public Guid ClientId { get; set; }
+
+        [Description("If this viewmodel is being returned in the context of the application's link to the user, " +
+                     "a list of scopes the application has been granted by the user should be populated")]
+        public List<Scope> Scopes { get; set; } = null;
     }
 }

--- a/OIDC.Core-API/OIDC.Core-API.csproj
+++ b/OIDC.Core-API/OIDC.Core-API.csproj
@@ -16,7 +16,6 @@
       </PackageReference>
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
-      <PackageReference Include="Pyromaniac" Version="1.0.0" />
       <PackageReference Include="RazorEngineCore" Version="2022.1.2" />
       <PackageReference Include="YamlDotNet" Version="11.2.1" />
       <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />

--- a/OIDC.Core-API/OIDC.Core-API.csproj
+++ b/OIDC.Core-API/OIDC.Core-API.csproj
@@ -16,6 +16,7 @@
       </PackageReference>
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+      <PackageReference Include="Pyromaniac" Version="1.0.0" />
       <PackageReference Include="RazorEngineCore" Version="2022.1.2" />
       <PackageReference Include="YamlDotNet" Version="11.2.1" />
       <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />

--- a/OIDC.Core-API/Services/Implementation/ApplicationService.cs
+++ b/OIDC.Core-API/Services/Implementation/ApplicationService.cs
@@ -32,6 +32,11 @@ namespace OAuthServer.Services.Implementation
             return await _context.Applications.FirstOrDefaultAsync(a => a.ClientId.Equals(clientId));
         }
 
+        public async Task<IList<Application>> FindByAuthorAsync(User user)
+        {
+            return await _context.Applications.Where(a => a.Author.Equals(user)).ToListAsync();
+        }
+
         public async Task<Application> CreateAsync(CreateRequestViewModel vm, User user)
         {
             Application application = new Application

--- a/OIDC.Core-API/Services/Interface/IApplicationService.cs
+++ b/OIDC.Core-API/Services/Interface/IApplicationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using OAuthServer.DAL.Entities;
 using OAuthServer.DAL.ViewModels.Controllers.Applications;
@@ -9,6 +10,7 @@ namespace OAuthServer.Services.Interface
     {
         Task<Application> FindAsync(Guid id);
         Task<Application> FindByClientIdAsync(Guid clientId);
+        Task<IList<Application>> FindByAuthorAsync(User user);
         Task<Application> CreateAsync(CreateRequestViewModel vm, User user);
         Task<Application> UpdateAsync(CreateRequestViewModel vm, Application application);
         Task<Application> DeleteAsync(Application application);

--- a/OIDC.Core-API/Startup.cs
+++ b/OIDC.Core-API/Startup.cs
@@ -86,7 +86,8 @@ namespace OAuthServer
             app.UseCors("open");
 
             app.UseMiddleware<VerifyAccessToken>();
-
+            // app.UseMiddleware<Pyromaniac.Pyromaniac>();
+            
             app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
         }
     }

--- a/OIDC.Core-APITest/Utility/Attributes/AuthoriseAttributeTest.cs
+++ b/OIDC.Core-APITest/Utility/Attributes/AuthoriseAttributeTest.cs
@@ -54,7 +54,7 @@ public class AuthoriseAttributeTest
         Dictionary<object, object?> contextItems = new() { { "User", user } };
         ActionContext actionContext = BuildActionContext(contextItems);
         AuthorizationFilterContext context = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
-        
+
         _attribute.OnAuthorization(context);
         JsonResult result = context.Result as JsonResult ?? throw new InvalidOperationException();
 

--- a/OIDC.Core.sln
+++ b/OIDC.Core.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OIDC.Core-API", "OIDC.Core-
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OIDC.Core-APITest", "OIDC.Core-APITest\OIDC.Core-APITest.csproj", "{E67EC2DC-B8BD-41CB-9E67-A32807A19549}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OIDC.Core-Provision", "OIDC.Core-Provision\OIDC.Core-Provision.csproj", "{F3ED3D43-ED5A-4F54-859B-771434AE2E91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{E67EC2DC-B8BD-41CB-9E67-A32807A19549}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E67EC2DC-B8BD-41CB-9E67-A32807A19549}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E67EC2DC-B8BD-41CB-9E67-A32807A19549}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3ED3D43-ED5A-4F54-859B-771434AE2E91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3ED3D43-ED5A-4F54-859B-771434AE2E91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3ED3D43-ED5A-4F54-859B-771434AE2E91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3ED3D43-ED5A-4F54-859B-771434AE2E91}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR's mostly just to clear down my local environment, there's a few things in here i've probably lost track of but from looking at the diff the following seems to be here;

- Return a list of scopes in `GET /applications` response
- Add a nullable `Scopes` property to the Application ViewModel to assist with contextualising
- Add a published applications endpoint
- Add an icon to the Scope entity + migration
- Add [`Pyromaniac`](https://github.com/DLMousey/Pyromaniac) middleware reference, then immediately comment out because i can't get enough of bloating my dependencies apparently 